### PR TITLE
don't access networkResponse directly

### DIFF
--- a/app/src/main/java/com/pixlee/pixleeandroidsdk/SampleActivity.java
+++ b/app/src/main/java/com/pixlee/pixleeandroidsdk/SampleActivity.java
@@ -168,7 +168,7 @@ public class SampleActivity extends AppCompatActivity implements PXLAlbum.Reques
     private void createAlbum() {
         Context c = this.getApplicationContext();
         PXLClient.initialize("196i8ZzIAhKU8dO2kDe");
-        album = new PXLAlbum("205365", c);
+        album = new PXLAlbum("2696111", c);
         PXLAlbumFilterOptions fo = new PXLAlbumFilterOptions();
         fo.minTwitterFollowers = 0;
         fo.minInstagramFollowers = 1;

--- a/pixleesdk/src/main/java/com/pixlee/pixleesdk/PXLClient.java
+++ b/pixleesdk/src/main/java/com/pixlee/pixleesdk/PXLClient.java
@@ -192,8 +192,7 @@ public class PXLClient {
             @Override
             public void onErrorResponse(VolleyError error) {
                 Log.w(TAG, "got an error response");
-                Log.w(TAG, String.format("%d: %s", error.networkResponse.statusCode, error.getMessage()));
-
+                Log.w(TAG, error.toString());
             }
         }){
             @Override


### PR DESCRIPTION
@jchen123  pretty sure this will fix the crashes, dug through the internet and found: https://stackoverflow.com/questions/22948006/http-status-code-in-android-volley-when-error-networkresponse-is-null/40053528
 form the accepted answer "It turns out that it is impossible to guarantee that error.networkResponse is non-null without modifying Google Volley code because of a bug in Volley that throws the Exception NoConnectionError for Http Status Code 401 "