### PR TITLE
correct content type

### DIFF
--- a/pixleesdk/src/main/java/com/pixlee/pixleesdk/PXLPhoto.java
+++ b/pixleesdk/src/main/java/com/pixlee/pixleesdk/PXLPhoto.java
@@ -183,7 +183,7 @@ public class PXLPhoto {
             this.userName = obj.getString("user_name");
             this.connectedUserId = obj.optInt("connected_user_id");
             this.source = obj.getString("source");
-            this.contentType = obj.optString("contentType");
+            this.contentType = obj.optString("content_type");
             this.dataFileName = obj.optString("data_file_name");
             this.mediumUrl = JsonUtils.getURL("medium_url", obj);
             this.bigUrl = JsonUtils.getURL("big_url", obj);


### PR DESCRIPTION
JIRA: https://pixlee.atlassian.net/browse/BUGZ-4830

Dunno how this ever worked...?  But makes sense since they were complaining about content_type being null since `contentType` is never returned in the JSON, it's always `content_type`