### PR TITLE
Hotfix for crashing due to trying to decode '%'

### DIFF
--- a/pixleesdk/src/main/java/com/pixlee/pixleesdk/PXLProduct.java
+++ b/pixleesdk/src/main/java/com/pixlee/pixleesdk/PXLProduct.java
@@ -43,11 +43,11 @@ public class PXLProduct {
         this.id = obj.optString("id");
         this.photo = photo;
         this.link = JsonUtils.getURL("link", obj);
-        this.linkText = JsonUtils.optDecodeString("link_text", obj);
+        this.linkText = obj.optString("link_text");
         this.image = JsonUtils.getURL("image", obj);
         this.imageThumb = JsonUtils.getURL("image_thumb", obj);
-        this.title = JsonUtils.optDecodeString("title", obj);
+        this.title = obj.optString("title");
         this.sku = obj.optString("sku");
-        this.description = JsonUtils.optDecodeString("link_text", obj);
+        this.description = obj.optString("description");
     }
 }


### PR DESCRIPTION
This hotfix fix the problem of https://pixlee.atlassian.net/browse/BUGZ-5527.

Since our server decode texts before sending response data, there is no need to decode texts on the SDK side. So I removed all decoding things from this SDK.