### PR TITLE
Moved unnecessary codes for checking secretKey to where it is used

### DIFF
--- a/pixleesdk/src/main/java/com/pixlee/pixleesdk/PXLClient.java
+++ b/pixleesdk/src/main/java/com/pixlee/pixleesdk/PXLClient.java
@@ -38,10 +38,7 @@ public class PXLClient {
     BasicDataSource basicRepo;
     AnalyticsDataSource analyticsRepo;
 
-    public synchronized BasicDataSource getBasicrepo() throws Exception {
-        if (PXLClient.apiKey == null || PXLClient.secretKey == null) {
-            throw new Exception();
-        }
+    public synchronized BasicDataSource getBasicrepo() {
         if (basicRepo == null) {
             basicRepo = NetworkModule.generateBasicRepository();
         }
@@ -49,11 +46,7 @@ public class PXLClient {
         return basicRepo;
     }
 
-    public AnalyticsDataSource getAnalyticsRepo() throws Exception {
-        if (PXLClient.apiKey == null || PXLClient.secretKey == null) {
-            throw new Exception();
-        }
-
+    public AnalyticsDataSource getAnalyticsRepo() {
         if (analyticsRepo == null) {
             analyticsRepo = NetworkModule.getAnalyticsRepository();
         }
@@ -61,8 +54,11 @@ public class PXLClient {
     }
 
     private PXLClient(Context context) {
-        mCtx = context;
+        if (PXLClient.apiKey == null ) {
+            throw new IllegalArgumentException("no apiKey, please set apiKey before start");
+        }
 
+        mCtx = context;
         android_id = Secure.getString(mCtx.getContentResolver(), Secure.ANDROID_ID);
 
     }

--- a/pixleesdk/src/main/java/com/pixlee/pixleesdk/data/repository/BasicRepository.java
+++ b/pixleesdk/src/main/java/com/pixlee/pixleesdk/data/repository/BasicRepository.java
@@ -42,6 +42,10 @@ public class BasicRepository implements BasicDataSource {
 
     @Override
     public Call<String> postMedia(String api_key, JSONObject json) {
+        if (PXLClient.secretKey == null ) {
+            throw new IllegalArgumentException("no secretKey, please set secretKey before start");
+        }
+
         String signiture = null;
 
         try {


### PR DESCRIPTION
I previously added this logic, checking the availability of **secretKey** for initiating this library but this is not necessary. There is a better place to check the availability of **secretKey**.

I moved the codes to where it is used because some of our clients do not need secretKey at all for retrieving photos.