### PR TITLE
Fix a bug of crashing due to lack of a http-code checker

### DIFF
--- a/pixleesdk/src/main/java/com/pixlee/pixleesdk/PXLPdpAlbum.java
+++ b/pixleesdk/src/main/java/com/pixlee/pixleesdk/PXLPdpAlbum.java
@@ -3,14 +3,9 @@ package com.pixlee.pixleesdk;
 import android.content.Context;
 import android.util.Log;
 
-import org.json.JSONException;
-import org.json.JSONObject;
-
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 
-import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
@@ -76,11 +71,8 @@ public class PXLPdpAlbum extends PXLAlbum {
                             @Override
                             public void onResponse(Call<String> call, Response<String> response) {
                                 try {
-                                    String result = response.body();
-                                    Log.e("retrofit result","retrofit result:" + result);
-                                    JSONObject json = new JSONObject(result);
-                                    JsonReceived(json);
-                                } catch (JSONException e) {
+                                    processResponse(response);
+                                } catch (Exception e) {
                                     e.printStackTrace();
                                 }
                             }

--- a/pixleesdk/src/main/java/com/pixlee/pixleesdk/PXLPhoto.java
+++ b/pixleesdk/src/main/java/com/pixlee/pixleesdk/PXLPhoto.java
@@ -81,6 +81,42 @@ public class PXLPhoto {
         void photoLoadFailed(String error);
     }
 
+    /**
+     * This deals with network responses
+     * when HTTP-code is in between 200 and 299, this method returns the body
+     * when HTTP-code is not in between 200 and 299, this method returns the error body
+     *
+     * @param response Retrofit's string body
+     */
+    protected static void processResponse(Response<String> response, PhotoLoadHandlers callback) {
+        try {
+            String result = response.body();
+            if (response.isSuccessful()) {
+                JSONObject json = new JSONObject(result);
+                JSONObject data = json.optJSONObject("data");
+                if(data!=null) {
+                    if (callback != null) {
+                        callback.photoLoaded(PXLPhoto.fromJsonObj(data));
+                    }
+                }else{
+                    Log.e(TAG, "no data from successful api call");
+                }
+            } else {
+                ResponseBody errorBody = response.errorBody();
+                if (errorBody != null) {
+                    if (callback != null) {
+                        callback.photoLoadFailed(errorBody.toString());
+                    }
+                } else {
+                    Log.e(TAG, "no data from failed api call");
+                }
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
     /***
      * Generates an ArrayList of PXLPhoto from the given JSON array.
      * @param data - JSONArray of Pixlee photos
@@ -122,19 +158,7 @@ public class PXLPhoto {
                             new Callback<String>() {
                                 @Override
                                 public void onResponse(Call<String> call, Response<String> response) {
-                                    try {
-                                        JSONObject json = new JSONObject(response.body());
-                                        JSONObject data = json.optJSONObject("data");
-                                        if (data == null) {
-                                            Log.e(TAG, "no data from successful api call");
-                                        } else {
-                                            if (callback != null) {
-                                                callback.photoLoaded(PXLPhoto.fromJsonObj(data));
-                                            }
-                                        }
-                                    } catch (JSONException e) {
-                                        e.printStackTrace();
-                                    }
+                                    processResponse(response, callback);
                                 }
 
                                 @Override
@@ -166,19 +190,7 @@ public class PXLPhoto {
                             new Callback<String>() {
                                 @Override
                                 public void onResponse(Call<String> call, Response<String> response) {
-                                    try {
-                                        JSONObject json = new JSONObject(response.body());
-                                        JSONObject data = json.optJSONObject("data");
-                                        if (data == null) {
-                                            Log.e(TAG, "no data from successful api call");
-                                        } else {
-                                            if (callback != null) {
-                                                callback.photoLoaded(PXLPhoto.fromJsonObj(data));
-                                            }
-                                        }
-                                    } catch (JSONException e) {
-                                        e.printStackTrace();
-                                    }
+                                    processResponse(response, callback);
                                 }
 
                                 @Override


### PR DESCRIPTION
When the SDK gets HTTP-error codes, the app leads to crashing. This crash is because of my mistake. When I added Retrofit, I should have added this code.  

This is just an urgent hotfix requested by Aritaum which could affect other SDK users. For the next task, I'll add test codes that mimic http-error codes so that the SDK will not have the same problem.

