### PR TITLE
Improve the use of content_source parameter

### DIFF
--- a/app/src/main/java/com/pixlee/pixleeandroidsdk/ui/gallery/GalleryFragment.java
+++ b/app/src/main/java/com/pixlee/pixleeandroidsdk/ui/gallery/GalleryFragment.java
@@ -96,7 +96,7 @@ public class GalleryFragment extends BaseFragment implements PXLAlbum.RequestHan
 
         /* ~~~ content source and content filter examples ~~~
           ArrayList contentSource = new ArrayList();
-          contentSource.add(PXLContentSource.INSTAGRAM);
+          contentSource.add(PXLContentSource.INSTAGRAM_FEED);
           fo.contentSource = contentSource;
 
           ArrayList contentType = new ArrayList();

--- a/pixleesdk/src/main/java/com/pixlee/pixleesdk/PXLAlbumFilterOptions.java
+++ b/pixleesdk/src/main/java/com/pixlee/pixleesdk/PXLAlbumFilterOptions.java
@@ -56,6 +56,13 @@ public class PXLAlbumFilterOptions {
                 JSONArray sources = new JSONArray();
                 for (int i = 0; i < contentSource.size(); i++) {
                     sources.put(contentSource.get(i).value);
+
+                    // if instagram_feed or instagram_story is added here, instagram has to be added together.
+                    // this is a rule. For your understanding, please read the comment of 'content_source' on this document: https://developers.pixlee.com/reference#consuming-content
+                    if (PXLContentSource.INSTAGRAM_FEED == contentSource.get(i) ||
+                            PXLContentSource.INSTAGRAM_STORY == contentSource.get(i)) {
+                        sources.put("instagram");
+                    }
                 }
                 jsonFilters.put("content_source", sources);
             }

--- a/pixleesdk/src/main/java/com/pixlee/pixleesdk/PXLContentSource.java
+++ b/pixleesdk/src/main/java/com/pixlee/pixleesdk/PXLContentSource.java
@@ -4,7 +4,8 @@ package com.pixlee.pixleesdk;
  * enum of the valid Pixlee content sources
  */
 public enum PXLContentSource {
-    INSTAGRAM ("instagram"),
+    INSTAGRAM_FEED ("instagram_feed"),
+    INSTAGRAM_STORY("instagram_story"),
     TWITTER ("twitter"),
     FACEBOOK ("facebook"),
     API ("api"),


### PR DESCRIPTION
This update is to prevent the wrong use of the SDK.

Based on this doc (https://developers.pixlee.com/reference#consuming-content), there is an ambiguousness in composing a filter using **key: content_source, value: intagram_feed or instagram_story**. When using one of intagram_feed and instagram_story, adding another value additionally to content_source is essential which is **instagram**.

Ideal URL: https://distillery.pixlee.com/api/v2/albums/12598895/photos?api_key=CgLNEXLCR4PJHNwNLc2d&filters={"content_source":["instagram_feed","instagram"]}&per_page=20&page=1