### PR TITLE
Remove a duplication of a request parameter

### DIFF
--- a/app/src/main/java/com/pixlee/pixleeandroidsdk/ui/gallery/GalleryFragment.java
+++ b/app/src/main/java/com/pixlee/pixleeandroidsdk/ui/gallery/GalleryFragment.java
@@ -94,10 +94,6 @@ public class GalleryFragment extends BaseFragment implements PXLAlbum.RequestHan
         fo.minTwitterFollowers = 0;
         fo.minInstagramFollowers = 0;
 
-        ArrayList contentSource = new ArrayList();
-        contentSource.add(PXLContentSource.INSTAGRAM_FEED);
-        contentSource.add(PXLContentSource.INSTAGRAM_STORY);
-        fo.contentSource = contentSource;
         /* ~~~ content source and content filter examples ~~~
           ArrayList contentSource = new ArrayList();
           contentSource.add(PXLContentSource.INSTAGRAM_FEED);

--- a/app/src/main/java/com/pixlee/pixleeandroidsdk/ui/gallery/GalleryFragment.java
+++ b/app/src/main/java/com/pixlee/pixleeandroidsdk/ui/gallery/GalleryFragment.java
@@ -22,6 +22,7 @@ import com.pixlee.pixleesdk.PXLAlbumSortOptions;
 import com.pixlee.pixleesdk.PXLAlbumSortType;
 import com.pixlee.pixleesdk.PXLBaseAlbum;
 import com.pixlee.pixleesdk.PXLClient;
+import com.pixlee.pixleesdk.PXLContentSource;
 import com.pixlee.pixleesdk.PXLPhoto;
 import com.pixlee.pixleesdk.PXLPhotoSize;
 import com.pixlee.pixleesdk.PXLWidgetType;
@@ -93,10 +94,14 @@ public class GalleryFragment extends BaseFragment implements PXLAlbum.RequestHan
         fo.minTwitterFollowers = 0;
         fo.minInstagramFollowers = 0;
 
-
+        ArrayList contentSource = new ArrayList();
+        contentSource.add(PXLContentSource.INSTAGRAM_FEED);
+        contentSource.add(PXLContentSource.INSTAGRAM_STORY);
+        fo.contentSource = contentSource;
         /* ~~~ content source and content filter examples ~~~
           ArrayList contentSource = new ArrayList();
           contentSource.add(PXLContentSource.INSTAGRAM_FEED);
+          contentSource.add(PXLContentSource.INSTAGRAM_STORY);
           fo.contentSource = contentSource;
 
           ArrayList contentType = new ArrayList();

--- a/pixleesdk/src/main/java/com/pixlee/pixleesdk/PXLAlbumFilterOptions.java
+++ b/pixleesdk/src/main/java/com/pixlee/pixleesdk/PXLAlbumFilterOptions.java
@@ -53,14 +53,17 @@ public class PXLAlbumFilterOptions {
             jsonFilters.putOpt("filter_by_radius", filterByRadius);
             //TODO: handle the arrays and dates properly
             if (contentSource != null && contentSource.size() > 0) {
+                boolean isInstagramAdded = false;
                 JSONArray sources = new JSONArray();
                 for (int i = 0; i < contentSource.size(); i++) {
                     sources.put(contentSource.get(i).value);
 
                     // if instagram_feed or instagram_story is added here, instagram has to be added together.
                     // this is a rule. For your understanding, please read the comment of 'content_source' on this document: https://developers.pixlee.com/reference#consuming-content
-                    if (PXLContentSource.INSTAGRAM_FEED == contentSource.get(i) ||
-                            PXLContentSource.INSTAGRAM_STORY == contentSource.get(i)) {
+                    if (!isInstagramAdded &&
+                            (PXLContentSource.INSTAGRAM_FEED == contentSource.get(i) ||
+                                    PXLContentSource.INSTAGRAM_STORY == contentSource.get(i))) {
+                        isInstagramAdded = true;
                         sources.put("instagram");
                     }
                 }


### PR DESCRIPTION
Removed duplicated 'instagram' contentSource if instagram_feed and instagram_story are added together. 

But the Distillary API still works fine although there is this duplication.