### PR TITLE
Replace salesEndDate with salesStartDate

### DIFF
--- a/pixleesdk/src/main/java/com/pixlee/pixleesdk/data/PXLProduct.java
+++ b/pixleesdk/src/main/java/com/pixlee/pixleesdk/data/PXLProduct.java
@@ -74,7 +74,7 @@ public class PXLProduct implements Parcelable {
             isWithinSalesDateRange = salesStartDate.getTime() <= today.getTime();
         } else if (salesStartDate == null && salesEndDate != null) {
             isWithinSalesDateRange = salesEndDate.getTime() >= today.getTime();
-        } else if (salesEndDate != null && salesEndDate != null) {
+        } else if (salesStartDate != null && salesEndDate != null) {
             isWithinSalesDateRange = salesStartDate.getTime() <= today.getTime() && salesEndDate.getTime() >= today.getTime();
         }
 


### PR DESCRIPTION
I made a silly mistake which I have fixed in photos repo.

`} else if (salesEndDate != null && salesEndDate != null) {` should be 
`} else if (salesStartDate != null && salesEndDate != null) {`
