### PR TITLE
Remove a horizontal line of was old price

### DIFF
--- a/pixleesdk/src/main/java/com/pixlee/pixleesdk/ui/viewholder/ProductViewHolder.kt
+++ b/pixleesdk/src/main/java/com/pixlee/pixleesdk/ui/viewholder/ProductViewHolder.kt
@@ -310,8 +310,10 @@ fun SpannableString.applyDisabledTextStyle(discountLayout: ProductViewHolder.Dis
         val fontSize = (TypedValue.applyDimension(it.sizeUnit, it.size, metrics) * disabledTextSizeRatio).toInt()
         setSpan(AbsoluteSizeSpan(fontSize), startIndex, endIndex, 0) // font size
         setSpan(ForegroundColorSpan(lighten(it.color, lightenFriction)), startIndex, endIndex, 0) // font color
-        setSpan(StrikethroughSpan(), startIndex, endIndex, 0) // font size
-
+        if (discountLayout == null ||
+                (discountLayout == ProductViewHolder.DiscountLayout.WITH_DISCOUNT_LABEL || discountLayout == ProductViewHolder.DiscountLayout.CROSS_THROUGH) ) {
+            setSpan(StrikethroughSpan(), startIndex, endIndex, 0) // font size
+        }
     }
 }
 

--- a/pixleesdk/src/main/res/layout/item_product.xml
+++ b/pixleesdk/src/main/res/layout/item_product.xml
@@ -31,7 +31,7 @@
 
         <TextView
             android:id="@+id/tvMain"
-            android:layout_width="200dp"
+            android:layout_width="220dp"
             android:layout_height="wrap_content"
             android:paddingTop="5dp"
             android:paddingLeft="@dimen/product_center"
@@ -46,7 +46,7 @@
             />
         <TextView
             android:id="@+id/tvSub"
-            android:layout_width="200dp"
+            android:layout_width="220dp"
             android:layout_height="wrap_content"
             android:paddingLeft="@dimen/product_center"
             android:maxLines="2"
@@ -64,8 +64,9 @@
 
         <TextView
             android:id="@+id/tvPrice"
-            android:layout_width="match_parent"
+            android:layout_width="220dp"
             android:layout_height="wrap_content"
+            android:includeFontPadding="false"
             tools:text="100"
             tools:textSize="30sp"
             android:paddingTop="5dp"

--- a/pixleesdk/src/main/res/values-ru/strings.xml
+++ b/pixleesdk/src/main/res/values-ru/strings.xml
@@ -1,5 +1,5 @@
 <resources>
     <string name="app_name">Pixlee SDK</string>
     <string name="was_old_price">был %s</string>
-    <string name="percent_off">%s%% выключенный</string>
+    <string name="percent_off">\n%s%% выключенный</string>
 </resources>


### PR DESCRIPTION
One of the display options of sales price has a bug which has a horizontal line that should be shown. This pr removes that line.

DiscountLayout.WAS_OLD_PRICE
|Old|New|
|---------|---------|
|<img src="https://i.ibb.co/HVHprW6/was-old-price.jpg" width="300">|<img src="https://i.ibb.co/SPLSds8/Screen-Shot-2021-05-03-at-6-25-06-PM.png" width="300">|
