### PR TITLE
Make timeouts for API calls editable

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ This SDK makes it easy for Pixlee customers to find and download Pixlee images a
                 // (Optional) if you use multi-region, you can set your region id here to get photos, a photo, and products available in the region.
                 val regionId:Int? = null // replace this value with yours
                 PXLClient.regionId = regionId
+
+                // (Optional) if you need to change timeouts of APIs, you can do it with these.
+                PXLClient.apiTimeoutRead = null // the default is 60 seconds
+                PXLClient.apiTimeoutConnect = null // the default is 60 seconds
+                PXLClient.apiTimeoutWrite = null // the default is 180 seconds
             }
         }
         ```

--- a/app/src/main/java/com/pixlee/pixleeandroidsdk/AppApplication.kt
+++ b/app/src/main/java/com/pixlee/pixleeandroidsdk/AppApplication.kt
@@ -20,5 +20,10 @@ class AppApplication: Application() {
         // (Optional) if you use multi-region, you can set your region id here to get photos, a photo, and products available in the region.
         val regionId:Int? = null
         PXLClient.regionId = regionId
+
+        // (Optional) if you need to change timeouts of APIs, you can do it with these.
+        PXLClient.apiTimeoutRead = null // null will use 60 seconds
+        PXLClient.apiTimeoutConnect = null // null will use 60 seconds
+        PXLClient.apiTimeoutWrite = null // null will use 180 seconds
     }
 }

--- a/doc/kotlin/API.md
+++ b/doc/kotlin/API.md
@@ -90,9 +90,14 @@ class YourApplication: Application {
         super.onCreate()
         ... // initializing SDK
 
-        // if you have multi-region, give the right region id. If you don't know about your region ids, Please reach out your Customer Success Manager.
-        // if you don't use multi-region, just ignore this line or give it null (ex: PXLClient.regionId = null)
-        PXLClient.regionId = your region id
+        // (Optional) if you use multi-region, you can set your region id here to get photos, a photo, and products available in the region.
+        val regionId:Int? = null // replace this value with yours
+        PXLClient.regionId = regionId
+
+        // (Optional) if you need to change timeouts of APIs, you can do it with these.
+        PXLClient.apiTimeoutRead = null // the default is 60 seconds
+        PXLClient.apiTimeoutConnect = null // the default is 60 seconds
+        PXLClient.apiTimeoutWrite = null // the default is 180 seconds
         ...
     }
 }

--- a/doc/kotlin/INDEX.md
+++ b/doc/kotlin/INDEX.md
@@ -34,6 +34,16 @@ You must do this before using this SDK!!
 PXLClient.regionId = your region id <--- set it if you use multi-region.
 ```
 
+### (Optional) API timeouts
+- if you need to change timeouts for connecting to our server, you can do it with these.
+```kotlin
+#!kotlin
+PXLClient.apiTimeoutRead = <yours> // the default is 60 seconds
+PXLClient.apiTimeoutConnect = <yours> // the default is 60 seconds
+PXLClient.apiTimeoutWrite = <yours> // the default is 180 seconds
+```
+
+
 ### (Optional) Automatic Analytics
 ```swift
 #!swift

--- a/pixleesdk/src/main/java/com/pixlee/pixleesdk/client/PXLClient.kt
+++ b/pixleesdk/src/main/java/com/pixlee/pixleesdk/client/PXLClient.kt
@@ -54,6 +54,13 @@ class PXLClient(val context: Context) {
             }
             return mInstance!!
         }
+
+        /**
+         * PXLClient can be reset if you need.
+         */
+        fun reset() {
+            mInstance = null
+        }
     }
 
     init {

--- a/pixleesdk/src/main/java/com/pixlee/pixleesdk/client/PXLClient.kt
+++ b/pixleesdk/src/main/java/com/pixlee/pixleesdk/client/PXLClient.kt
@@ -22,6 +22,10 @@ class PXLClient(val context: Context) {
         var secretKey: String? = null
         var android_id: String? = null
 
+        var apiTimeoutRead: Long? = null
+        var apiTimeoutConnect: Long? = null
+        var apiTimeoutWrite: Long? = null
+
         // region id differentiates analytics events by region
         var regionId: Int? = null
 

--- a/pixleesdk/src/main/java/com/pixlee/pixleesdk/network/NetworkModule.java
+++ b/pixleesdk/src/main/java/com/pixlee/pixleesdk/network/NetworkModule.java
@@ -5,6 +5,7 @@ import android.util.Log;
 
 import com.orhanobut.logger.Logger;
 import com.pixlee.pixleesdk.BuildConfig;
+import com.pixlee.pixleesdk.client.PXLClient;
 import com.pixlee.pixleesdk.data.api.AnalyticsAPI;
 import com.pixlee.pixleesdk.data.api.BasicAPI;
 import com.pixlee.pixleesdk.data.api.KtxAnalyticsAPI;
@@ -83,10 +84,6 @@ public class NetworkModule {
     public static final String url = "https://distillery.pixlee.com/";
     public static final String analyticsUrl = "https://inbound-analytics.pixlee.com/events/";
 
-    private static final Long timeout_read = 60L;
-    private static final Long timeout_connect = 60L;
-    private static final Long timeout_write = 180L;
-
     public static Moshi provideMoshi() {
         return new Moshi.Builder()
                 .add(Wrapped.ADAPTER_FACTORY)
@@ -111,10 +108,17 @@ public class NetworkModule {
 
     public static synchronized OkHttpClient provideOkHttpClient() {
         if (okHttpClient == null) {
+            Long timeoutConnect = 60L;
+            Long timeoutRead = 60L;
+            Long timeoutWrite = 180L;
+            if (PXLClient.Companion.getApiTimeoutConnect() != null) timeoutConnect = PXLClient.Companion.getApiTimeoutConnect();
+            if (PXLClient.Companion.getApiTimeoutRead() != null) timeoutRead = PXLClient.Companion.getApiTimeoutRead();
+            if (PXLClient.Companion.getApiTimeoutWrite() != null) timeoutWrite = PXLClient.Companion.getApiTimeoutWrite();
+
             OkHttpClient.Builder ok = new OkHttpClient.Builder()
-                    .connectTimeout(timeout_connect, TimeUnit.SECONDS)
-                    .readTimeout(timeout_read, TimeUnit.SECONDS)
-                    .writeTimeout(timeout_write, TimeUnit.SECONDS);
+                    .connectTimeout(timeoutConnect, TimeUnit.SECONDS)
+                    .readTimeout(timeoutRead, TimeUnit.SECONDS)
+                    .writeTimeout(timeoutWrite, TimeUnit.SECONDS);
 
             // enable Tls12 on Pre Lollipop
             try {


### PR DESCRIPTION
This's to add a little freedom for the SKD users. Since there are use some cases of uploading large files, I think that the SDK users may need their own timeouts in firing APIs. This provides that option for them. This has to be configured only once before PXLClient is reset.