### PR TITLE
[hotfix] Fix analytics photos' value

### DIFF
--- a/pixleesdk/src/main/java/com/pixlee/pixleesdk/client/PXLBaseAlbum.java
+++ b/pixleesdk/src/main/java/com/pixlee/pixleesdk/client/PXLBaseAlbum.java
@@ -625,7 +625,7 @@ public abstract class PXLBaseAlbum {
         StringBuilder stringBuilder = new StringBuilder();
         for (int i = 0; i < this.photos.size(); i++) {
             try {
-                stringBuilder.append(this.photos.get(i).id);
+                stringBuilder.append(this.photos.get(i).albumPhotoId);
                 if (i != this.photos.size() - 1) {
                     stringBuilder.append(",");
                 }


### PR DESCRIPTION
https://pixleeturnto.slack.com/archives/C07HMV4D8/p1655367395796479

Replace photo id with album_photo_id for `photos` request parameter in these three analytics calls
- [openedWidget](https://developers.pixlee.com/reference/opened-widget)
- [widgetVisible](https://developers.pixlee.com/reference/widget-visible)
- [loadMore](https://developers.pixlee.com/reference/load-more)